### PR TITLE
fix: page routing and back buttons

### DIFF
--- a/src/components/molecules/TalkCard/TalkCard.tsx
+++ b/src/components/molecules/TalkCard/TalkCard.tsx
@@ -10,7 +10,7 @@ const cx = classNames.bind(styles);
 
 const TalkCard: React.FC<TalkJson> = ({ title, event, date, location }) => (
   <div className={cx("container")}>
-    <Link to={`/talks/country/${location.country}/${date}`} replace={true}>
+    <Link to={`/talk/detail/${date}`}>
       <div className={cx("head")}>
         <ColorCircle />
         <Text type="h3">{title}</Text>

--- a/src/components/pages/Post/Post.tsx
+++ b/src/components/pages/Post/Post.tsx
@@ -28,7 +28,7 @@ const Post: React.FC<RouteComponentProps<{ page: string }>> = ({
 
   React.useEffect(() => {
     setPosts(getPagedPostJson(searchedPosts));
-    history.push("/posts/1");
+    history.replace("/posts/1");
   }, [searchedPosts]);
 
   return (

--- a/src/components/pages/Root.tsx
+++ b/src/components/pages/Root.tsx
@@ -26,11 +26,7 @@ const Root: React.FC = () => {
           path="/talks/country/:country"
           component={TalkCity}
         />
-        <Route
-          exact={true}
-          path="/talks/country/:country/:date"
-          component={TalkDetail}
-        />
+        <Route exact={true} path="/talk/detail/:date" component={TalkDetail} />
         <Route exact={true} path="/posts/:page" component={Post} />
         <Route exact={true} path="/videos/:page" component={Video} />
         <Route exact={true} path="/about" component={About} />

--- a/src/components/pages/Talk/Talk.tsx
+++ b/src/components/pages/Talk/Talk.tsx
@@ -28,7 +28,7 @@ const Talk: React.FC<RouteComponentProps<{ page: string }>> = ({
 
   React.useEffect(() => {
     setTalks(getPagedTalkJson(searchedTalks));
-    history.push("/talks/1");
+    history.replace("/talks/1");
   }, [searchedTalks]);
 
   return (
@@ -83,4 +83,4 @@ const Talk: React.FC<RouteComponentProps<{ page: string }>> = ({
   );
 };
 
-export default withRouter(Talk);
+export default Talk;

--- a/src/components/pages/TalkCity/TalkCity.tsx
+++ b/src/components/pages/TalkCity/TalkCity.tsx
@@ -10,6 +10,7 @@ const cx = classNames.bind(styles);
 
 const TalkCity: React.FC<RouteComponentProps<{ country: string }>> = ({
   match,
+  history,
 }) => {
   const [pagedTalkJson, setPagedTalkJson] = React.useState(
     getPagedCountryTalkJson(match.params.country),

--- a/src/components/pages/TalkDetail/TalkDetail.scss
+++ b/src/components/pages/TalkDetail/TalkDetail.scss
@@ -13,6 +13,7 @@
   color: $fontLime;
   margin-right: 1rem;
   vertical-align: super;
+  cursor: pointer;
 }
 
 .arrow:hover {

--- a/src/components/pages/TalkDetail/TalkDetail.tsx
+++ b/src/components/pages/TalkDetail/TalkDetail.tsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames/bind";
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
-import { Link } from "react-router-dom";
 import { getTalkJson } from "../../../utils/getTalksJson";
 import Tag from "../../atoms/Tag/Tag";
 import Text from "../../atoms/Text/Text";
@@ -24,13 +23,13 @@ const TalkDetail: React.FC<RouteComponentProps<{ date: string }>> = ({
     <div className={cx("container")}>
       <div className={cx("leftColumn")}>
         <div className={cx("title")}>
-          <Link to={`/talks/1`}>
+          <span onClick={history.goBack} className={cx("backButton")}>
             <FontAwesomeIcon
               icon={faArrowLeft}
               size="2x"
               className={cx("arrow")}
             />
-          </Link>
+          </span>
           <Text type="h2" bold={true} italic={true} color="lime">
             {talk.title}
           </Text>


### PR DESCRIPTION
<img width="1440" alt="スクリーンショット 2019-04-21 14 58 32" src="https://user-images.githubusercontent.com/31027685/56466044-f48e5380-6445-11e9-8e9a-5556547214b0.png">

I fixed page routing according to this message.

> Another thing. When I click on a specific talk on the map and then click to go back to the list it doesn't return to the map view it goes to the list view