### PR TITLE
fix: fix the projects of About page and back buttons of all page

### DIFF
--- a/src/components/pages/About/About.scss
+++ b/src/components/pages/About/About.scss
@@ -26,6 +26,7 @@
 .arrow {
   margin-right: 1rem;
   vertical-align: super;
+  cursor: pointer;
 }
 
 .arrow:hover {
@@ -78,9 +79,4 @@
 
 .linkTitle:hover {
   opacity: 0.5;
-}
-
-.projects {
-  height: calc(100vh - 20rem);
-  overflow: scroll;
 }

--- a/src/components/pages/About/About.tsx
+++ b/src/components/pages/About/About.tsx
@@ -3,7 +3,7 @@ import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames/bind";
 import * as React from "react";
-import { Link as span, RouteComponentProps } from "react-router-dom";
+import { RouteComponentProps } from "react-router-dom";
 import photo from "../../../image/erickwendel.png";
 import { getPagedProjectJson } from "../../../utils/getProjectsJson";
 import Tag from "../../atoms/Tag/Tag";

--- a/src/components/pages/About/About.tsx
+++ b/src/components/pages/About/About.tsx
@@ -3,7 +3,7 @@ import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames/bind";
 import * as React from "react";
-import { Link } from "react-router-dom";
+import { Link as span, RouteComponentProps } from "react-router-dom";
 import photo from "../../../image/erickwendel.png";
 import { getPagedProjectJson } from "../../../utils/getProjectsJson";
 import Tag from "../../atoms/Tag/Tag";
@@ -27,20 +27,20 @@ const linkIcons: Array<{ type: LinkIconProps["type"]; href: string }> = [
 
 const tags = ["#opensource", "#nodejs", "#typescript"];
 
-const About: React.FC = ({}) => {
+const About: React.FC<RouteComponentProps> = ({ history }) => {
   const [projects, setProjects] = React.useState(getPagedProjectJson());
 
   return (
     <div className={cx("container")}>
       <div className={cx("leftColumn")}>
         <div className={cx("head")}>
-          <Link to="/">
+          <span onClick={history.goBack}>
             <FontAwesomeIcon
               icon={faArrowLeft}
               size="2x"
               className={cx("arrow", "icon")}
             />
-          </Link>
+          </span>
           <Text color="lime" type="h2" bold={true} italic={true}>
             About
           </Text>

--- a/src/components/pages/Post/Post.scss
+++ b/src/components/pages/Post/Post.scss
@@ -13,6 +13,7 @@
   color: $fontLime;
   margin-right: 1rem;
   vertical-align: super;
+  cursor: pointer;
 }
 
 .arrow:hover {

--- a/src/components/pages/Post/Post.tsx
+++ b/src/components/pages/Post/Post.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames/bind";
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
 import { withRouter } from "react-router";
-import { Link } from "react-router-dom";
+import { Link as span } from "react-router-dom";
 import postJson from "../../../resource/posts.json";
 import { PostJson } from "../../../types/posts";
 import { getPagedPostJson } from "../../../utils/getPostsJson";
@@ -34,13 +34,13 @@ const Post: React.FC<RouteComponentProps<{ page: string }>> = ({
   return (
     <div className={cx("container")}>
       <div className={cx("head")}>
-        <Link to="/">
+        <span onClick={history.goBack}>
           <FontAwesomeIcon
             icon={faArrowLeft}
             size="2x"
             className={cx("arrow")}
           />
-        </Link>
+        </span>
         <Text color="lime" type="h2" bold={true} italic={true}>
           Posts
         </Text>

--- a/src/components/pages/Post/Post.tsx
+++ b/src/components/pages/Post/Post.tsx
@@ -5,7 +5,6 @@ import classNames from "classnames/bind";
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
 import { withRouter } from "react-router";
-import { Link as span } from "react-router-dom";
 import postJson from "../../../resource/posts.json";
 import { PostJson } from "../../../types/posts";
 import { getPagedPostJson } from "../../../utils/getPostsJson";

--- a/src/components/pages/Talk/Talk.scss
+++ b/src/components/pages/Talk/Talk.scss
@@ -13,6 +13,7 @@
   color: $fontLime;
   margin-right: 1rem;
   vertical-align: super;
+  cursor: pointer;
 }
 
 .arrow:hover {

--- a/src/components/pages/Talk/Talk.tsx
+++ b/src/components/pages/Talk/Talk.tsx
@@ -4,8 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames/bind";
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
-import { withRouter } from "react-router";
-import { Link as span } from "react-router-dom";
 import talkJson from "../../../resource/talks.json";
 import { TalkJson } from "../../../types/talks";
 import { getPagedTalkJson } from "../../../utils/getTalksJson";

--- a/src/components/pages/Talk/Talk.tsx
+++ b/src/components/pages/Talk/Talk.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames/bind";
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
 import { withRouter } from "react-router";
-import { Link } from "react-router-dom";
+import { Link as span } from "react-router-dom";
 import talkJson from "../../../resource/talks.json";
 import { TalkJson } from "../../../types/talks";
 import { getPagedTalkJson } from "../../../utils/getTalksJson";
@@ -34,13 +34,13 @@ const Talk: React.FC<RouteComponentProps<{ page: string }>> = ({
   return (
     <div className={cx("container")}>
       <div className={cx("head")}>
-        <Link to="/">
+        <span onClick={history.goBack}>
           <FontAwesomeIcon
             icon={faArrowLeft}
             size="2x"
             className={cx("arrow")}
           />
-        </Link>
+        </span>
         <Text color="lime" type="h2" bold={true} italic={true}>
           Talks
         </Text>

--- a/src/components/pages/Video/Video.scss
+++ b/src/components/pages/Video/Video.scss
@@ -17,6 +17,7 @@
   color: $fontLime;
   margin-right: 1rem;
   vertical-align: super;
+  cursor: pointer;
 }
 
 .arrow:hover {

--- a/src/components/pages/Video/Video.tsx
+++ b/src/components/pages/Video/Video.tsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames/bind";
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
-import { Link as span } from "react-router-dom";
 import { VideoJson } from "../../../types/videos";
 import { getPagedVideoJson } from "../../../utils/getVideosJson";
 import Text from "../../atoms/Text/Text";

--- a/src/components/pages/Video/Video.tsx
+++ b/src/components/pages/Video/Video.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames/bind";
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
-import { Link } from "react-router-dom";
+import { Link as span } from "react-router-dom";
 import { VideoJson } from "../../../types/videos";
 import { getPagedVideoJson } from "../../../utils/getVideosJson";
 import Text from "../../atoms/Text/Text";
@@ -27,13 +27,13 @@ const Video: React.FC<RouteComponentProps<{ page: string }>> = ({
     <div className={cx("container")}>
       <ScrollToTop />
       <div className={cx("head")}>
-        <Link to="/">
+        <span onClick={history.goBack}>
           <FontAwesomeIcon
             icon={faArrowLeft}
             size="2x"
             className={cx("arrow")}
           />
-        </Link>
+        </span>
         <Text color="lime" type="h2" bold={true} italic={true}>
           Videos
         </Text>


### PR DESCRIPTION
fix the Projects' display.
<img width="1436" alt="スクリーンショット 2019-04-21 16 06 57" src="https://user-images.githubusercontent.com/31027685/56466669-8b134280-644f-11e9-9162-fc7d281bdf32.png">

And fix the back buttons of all pages.