### PR TITLE
fix: make mapText do not have pointer event

### DIFF
--- a/src/components/organisms/CityMap/CityMap.scss
+++ b/src/components/organisms/CityMap/CityMap.scss
@@ -11,6 +11,7 @@
 
 .mapText {
   display: none;
+  pointer-events: none;
 }
 
 .mapPin:hover + .mapText {


### PR DESCRIPTION
Fixed a flickering problem caused by mapText having a pointer event.
![screencast-hiraike32 github io-2019 04 21-16-27-19 (1)](https://user-images.githubusercontent.com/17416874/56467315-50fa6e80-6458-11e9-9ea3-245588a9f863.gif)
