### PR TITLE
feat: implement a sort by city

### DIFF
--- a/src/components/PC/organisms/TalkList/TalkList.tsx
+++ b/src/components/PC/organisms/TalkList/TalkList.tsx
@@ -5,7 +5,6 @@ import classNames from "classnames/bind";
 import * as React from "react";
 import { TalkJson } from "../../../../types/talks";
 import { getPagedTalksJson } from "../../../../utils/getTalksJson";
-import Button from "../../../Common/atoms/Button/Button";
 import ColorCircle from "../../../Common/atoms/ColorCircle/ColorCircle";
 import Text from "../../../Common/atoms/Text/Text";
 import Pager from "../../../Common/molecules/Pager/Pager";
@@ -30,13 +29,17 @@ const TalkList: React.FC<Props> = ({ title, goBack, talksJson }) => {
   const [searchedTalks, setSearchedTalks] = React.useState<TalkJson[]>(
     talksJson,
   );
-
   const totalCount = talksJson.length;
 
   React.useEffect(() => {
     setTalks(getPagedTalksJson(searchedTalks));
     setSelectedPage(1);
   }, [searchedTalks]);
+
+  React.useEffect(() => {
+    setTalks(getPagedTalksJson(talksJson));
+    setSelectedPage(1);
+  }, [talksJson]);
 
   return (
     <div className={cx("container")}>

--- a/src/components/PC/pages/TalkCity/TalkCity.tsx
+++ b/src/components/PC/pages/TalkCity/TalkCity.tsx
@@ -12,9 +12,7 @@ const TalkCity: React.FC<RouteComponentProps<{ country: string }>> = ({
   match,
   history,
 }) => {
-  const [countryTalksJson, setCountryTalksJson] = React.useState(
-    getCountryTalksJson(match.params.country),
-  );
+  const countryTalksJson = getCountryTalksJson(match.params.country);
   const [cityTalksJson, setCityTalksJson] = React.useState();
 
   return (

--- a/src/components/SP/organisms/TalkList/TalkList.tsx
+++ b/src/components/SP/organisms/TalkList/TalkList.tsx
@@ -37,6 +37,11 @@ const TalkList: React.FC<Props> = ({ title, goBack, talksJson }) => {
     setSelectedPage(1);
   }, [searchedTalks]);
 
+  React.useEffect(() => {
+    setTalks(getPagedTalksJson(talksJson));
+    setSelectedPage(1);
+  }, [talksJson]);
+
   return (
     <div className={cx("container")}>
       <div className={cx("title")}>


### PR DESCRIPTION
If you click a city on the city map, you can sort talks by the city you choose.
<img width="1437" alt="スクリーンショット 2019-05-03 14 58 17" src="https://user-images.githubusercontent.com/31027685/57121664-f6e09e00-6db3-11e9-85c6-798650b32119.png">
